### PR TITLE
Add sentence rewriting and remove private methods from docs

### DIFF
--- a/docs/source/modules/cli.rst
+++ b/docs/source/modules/cli.rst
@@ -5,12 +5,8 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.cli_utils
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/common.rst
+++ b/docs/source/modules/common.rst
@@ -5,26 +5,18 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.common.exceptions
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.common.logging
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.common.utils
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/config.rst
+++ b/docs/source/modules/config.rst
@@ -5,5 +5,3 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/constrainers.rst
+++ b/docs/source/modules/constrainers.rst
@@ -5,19 +5,13 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.constrainers.base
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.constrainers.length
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/data.rst
+++ b/docs/source/modules/data.rst
@@ -5,5 +5,3 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/exploration.rst
+++ b/docs/source/modules/exploration.rst
@@ -19,26 +19,18 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.exploration.attribution
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.exploration.boundary
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.exploration.mixcase
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/extractors.rst
+++ b/docs/source/modules/extractors.rst
@@ -5,103 +5,78 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.base
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.dummy
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.auxiliary
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.entity_list
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.noun_list
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.sentence_prefix
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.word_prefix
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.combined
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.sentence_gap
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.sentence_masking
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
+
+.. automodule:: text_machina.src.extractors.sentence_rewriting
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 .. automodule:: text_machina.src.extractors.word_gap
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.word_masking
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.utils
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.extractors.types
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/generators.rst
+++ b/docs/source/modules/generators.rst
@@ -5,40 +5,28 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.generators.base
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.generators.detection
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.generators.attribution
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.generators.boundary
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.generators.mixcase
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/metrics.rst
+++ b/docs/source/modules/metrics.rst
@@ -5,47 +5,33 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.metrics.base
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.metrics.mauve
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.metrics.perplexity
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.metrics.repetition_diversity
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.metrics.simple_model
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.metrics.token_classification
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -5,89 +5,63 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.base
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.ai21
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.anthropic
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.azure_openai
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.bedrock
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.cohere
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.hf_local
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.hf_remote
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.inference_server
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.openai
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.vertex
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.models.types
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/postprocessing.rst
+++ b/docs/source/modules/postprocessing.rst
@@ -5,5 +5,3 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/tokenizers.rst
+++ b/docs/source/modules/tokenizers.rst
@@ -5,82 +5,58 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.tokenizers.base
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
    
 .. automodule:: text_machina.src.tokenizers.ai21
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.tokenizers.anthropic
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.tokenizers.azure_openai
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.tokenizers.bedrock
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.tokenizers.cohere
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.tokenizers.hf_local
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.tokenizers.hf_remote
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.tokenizers.inference_server
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.tokenizers.openai
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:
 
 .. automodule:: text_machina.src.tokenizers.vertex
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/docs/source/modules/types.rst
+++ b/docs/source/modules/types.rst
@@ -5,5 +5,3 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :special-members:
-   :private-members:

--- a/etc/examples/learning/extractors/mixcase_sentence_rewriting.yaml
+++ b/etc/examples/learning/extractors/mixcase_sentence_rewriting.yaml
@@ -1,0 +1,45 @@
+# Config for everything related to dataset generation inputs
+input_config:
+    # Dataset metadata
+    domain: news
+    language: en
+
+    # Dataset generator parameters
+    quantity: 3
+    random_sample_human: true
+
+    # HuggingFace dataset params
+    dataset: xsum
+    dataset_text_column: document
+    dataset_params:
+        split: test
+
+    # Prompt template
+    template: >-
+        Rewrite the following sentence in your own words. Refrain to make
+        a verbatim copy of the sentence.\n
+        Sentence: {sentence}
+        Sentence rewritten: 
+
+    # Extractor params
+    extractor: sentence_rewriting
+    max_input_tokens: 1024
+    extractor_args:
+        sentence_rewriting:
+            percentage_range: [0.3, 0.4]
+
+# Config for model instantiation
+model_config:
+    provider: openai
+    model_name: gpt-4
+    api_type: CHAT
+    threads: 8
+    max_retries: 5
+    timeout: 120
+    
+# Decoding args
+generation_config:
+    # Ignore use `max_tokens` to get automatic length estimation
+    max_tokens: 1024
+    temperature: 0.7
+    presence_penalty: 1.0

--- a/text_machina/src/common/exceptions.py
+++ b/text_machina/src/common/exceptions.py
@@ -195,3 +195,20 @@ class ExtractorEmptyColumns(TextMachinaError):
         self.field = field
         msg = f"The extractor {extractor} returned empty '{field}'."
         super().__init__(msg)
+
+
+class ExtractorInvalidArgs(TextMachinaError):
+    """
+    Raised when mandatory arguments for an
+    extractor are invalid or not provided.
+    """
+
+    def __init__(self, extractor: str, extractor_args: List[str]):
+        self.extractor = extractor
+        self.extractor_args = extractor_args
+        msg = (
+            f"When using the extractor {extractor}, you must ensure that"
+            f" the following arguments: {', '.join(self.extractor_args)}"
+            " are valid."
+        )
+        super().__init__(msg)

--- a/text_machina/src/data.py
+++ b/text_machina/src/data.py
@@ -53,7 +53,6 @@ class PromptedDatasetBuilder:
         # truncate the prompt inputs and format the prompts
         prompt_inputs = self.truncate_inputs(prompt_inputs)
         inputs = format_prompt(self.prompt.template, prompt_inputs)
-
         return PromptedDataset(prompted_texts=inputs, human_texts=human_texts)
 
     def sampling(self, dataset: Dataset) -> Tuple[List[str], Dataset]:

--- a/text_machina/src/extractors/__init__.py
+++ b/text_machina/src/extractors/__init__.py
@@ -12,6 +12,7 @@ from .noun_list import NounList
 from .sentence_gap import SentenceGap
 from .sentence_masking import SentenceMasking
 from .sentence_prefix import SentencePrefix
+from .sentence_rewriting import SentenceRewriting
 from .word_gap import WordGap
 from .word_masking import WordMasking
 from .word_prefix import WordPrefix
@@ -25,6 +26,7 @@ EXTRACTORS: Mapping[str, Type[Extractor]] = {
     "sentence_prefix": SentencePrefix,
     "sentence_gap": SentenceGap,
     "sentence_masking": SentenceMasking,
+    "sentence_rewriting": SentenceRewriting,
     "word_prefix": WordPrefix,
     "word_gap": WordGap,
     "word_masking": WordMasking,

--- a/text_machina/src/extractors/base.py
+++ b/text_machina/src/extractors/base.py
@@ -14,11 +14,28 @@ class Extractor(ABC):
     Base class for an extractor.
     """
 
-    def __init__(self, input_config: InputConfig, task_type: TaskType):
+    def __init__(
+        self,
+        input_config: InputConfig,
+        task_type: TaskType,
+        workspace: Dict[str, Any] = {},
+        args: Dict[str, Any] = {},
+    ):
         self.input_config = input_config
         self.task_type = task_type
-        self.workspace: Dict[str, Any] = {}
-        self.args: Dict[str, Any] = {}
+        self.workspace: Dict[str, Any] = workspace
+        self.args: Dict[str, Any] = args
+        self.check_valid_args()
+
+    def check_valid_args(self) -> None:
+        """
+        Checks if the arguments passed to the extractor are valid.
+
+        Raises:
+            ExtractorInvalidArgs: if the arguments are invalid.
+
+        """
+        ...
 
     @abstractmethod
     def _extract(self, dataset: Dataset) -> Dict[str, List[str]]:

--- a/text_machina/src/extractors/sentence_gap.py
+++ b/text_machina/src/extractors/sentence_gap.py
@@ -1,9 +1,10 @@
 from math import ceil
 from random import randint
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from datasets import Dataset
 
+from ..common.exceptions import ExtractorInvalidArgs
 from ..config import InputConfig
 from ..types import TaskType
 from .base import Extractor
@@ -35,13 +36,27 @@ class SentenceGap(Extractor):
     """
 
     def __init__(self, input_config: InputConfig, task_type: TaskType):
-        super().__init__(input_config, task_type)
-        self.args = self.input_config.extractor_args.get("sentence_gap", {})
-        self.workspace = {
+        args: Dict[str, Any] = input_config.extractor_args.get(
+            "sentence_gap", {}
+        )
+        workspace: Dict[str, Any] = {
             "positions": [],
             "human_spans": [],
             "num_boundaries": [],
         }
+        super().__init__(input_config, task_type, workspace, args)
+
+    def check_valid_args(self):
+        mandatory_args = [
+            "gap_token",
+            "max_percentage_boundaries",
+            "max_sentence_span",
+        ]
+        for mandatory_arg in mandatory_args:
+            if mandatory_arg not in self.args:
+                raise ExtractorInvalidArgs(
+                    self.__class__.__name__, mandatory_args
+                )
 
     def prepare_human(self, human_texts: List[str]) -> List[str]:
         return [

--- a/text_machina/src/extractors/sentence_masking.py
+++ b/text_machina/src/extractors/sentence_masking.py
@@ -1,10 +1,11 @@
 from math import ceil
 from random import choice, sample, uniform
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from datasets import Dataset
 
 from ..common import color_log, get_logger
+from ..common.exceptions import ExtractorInvalidArgs
 from ..config import InputConfig
 from ..types import TaskType
 from .base import Extractor
@@ -32,9 +33,11 @@ class SentenceMasking(Extractor):
     """
 
     def __init__(self, input_config: InputConfig, task_type: TaskType):
-        super().__init__(input_config, task_type)
-        self.args = self.input_config.extractor_args.get("sentence_masking", {})
-        self.workspace = {"masked_texts": []}
+        args: Dict[str, Any] = input_config.extractor_args.get(
+            "sentence_masking", {}
+        )
+        workspace: Dict[str, Any] = {"masked_texts": []}
+        super().__init__(input_config, task_type, workspace, args)
 
         _logger.warn(
             color_log(
@@ -46,6 +49,14 @@ class SentenceMasking(Extractor):
                 "bold_yellow",
             )
         )
+
+    def check_valid_args(self):
+        mandatory_args = ["mask_token", "percentage_range"]
+        for mandatory_arg in mandatory_args:
+            if mandatory_arg not in self.args:
+                raise ExtractorInvalidArgs(
+                    self.__class__.__name__, mandatory_args
+                )
 
     def prepare_human(self, human_texts: List[str]) -> List[str]:
         return human_texts

--- a/text_machina/src/extractors/sentence_rewriting.py
+++ b/text_machina/src/extractors/sentence_rewriting.py
@@ -66,8 +66,8 @@ class SentenceRewriting(Extractor):
                 1,
                 ceil(uniform(*self.args["percentage_range"]) * len(sentences)),
             )
-            sampled_positions = sample(
-                [_ for _ in range(len(sentences))], n_sentences_to_select
+            sampled_positions = sorted(
+                sample(list(range(len(sentences))), n_sentences_to_select)
             )
             self.workspace["positions"].append(sampled_positions)
             for position in sampled_positions:

--- a/text_machina/src/extractors/sentence_rewriting.py
+++ b/text_machina/src/extractors/sentence_rewriting.py
@@ -1,5 +1,5 @@
 from math import ceil
-from random import randint, shuffle, uniform
+from random import randint, sample, uniform
 from typing import Any, Dict, List
 
 from datasets import Dataset
@@ -58,15 +58,16 @@ class SentenceRewriting(Extractor):
         sentences_to_rewrite = []
         for text in texts:
             sentences = list([sent.text_with_ws for sent in text.sents])
+            # Skip the sample if there are no sentences.
+            if len(sentences) == 0:
+                continue
             self.workspace["human_spans"].append(sentences)
             n_sentences_to_select = randint(
                 1,
                 ceil(uniform(*self.args["percentage_range"]) * len(sentences)),
             )
-            sampled_positions = [_ for _ in range(len(sentences))]
-            shuffle(sampled_positions)
-            sampled_positions = sorted(
-                sampled_positions[:n_sentences_to_select]
+            sampled_positions = sample(
+                [_ for _ in range(len(sentences))], n_sentences_to_select
             )
             self.workspace["positions"].append(sampled_positions)
             for position in sampled_positions:

--- a/text_machina/src/extractors/sentence_rewriting.py
+++ b/text_machina/src/extractors/sentence_rewriting.py
@@ -1,0 +1,67 @@
+from math import ceil
+from random import randint, shuffle, uniform
+from typing import Dict, List
+
+from datasets import Dataset
+
+from ..config import InputConfig
+from ..types import TaskType
+from .base import Extractor
+from .utils import spacy_pipeline
+
+
+class SentenceRewriting(Extractor):
+    """
+    Extractor that fills the prompt template with a sentence that
+    has to be rewritten by an LLM.
+
+    This extractor needs two template placeholders:
+
+
+    This extractor needs two template placeholders:
+        - {sentence}: will be filled with sentence to be rewritten.
+
+    This extractor allows to pass the following arguments in the
+    `extractor_args` field from the config:
+        - percentage_range (List[float]): range delimiting the percentage
+            of sentences to be rewritten. At least one sentence will be
+            always rewritten.
+    """
+
+    def __init__(self, input_config: InputConfig, task_type: TaskType):
+        super().__init__(input_config, task_type)
+        self.args = self.input_config.extractor_args.get(
+            "sentence_rewriting", {}
+        )
+        self.workspace = {"positions": [], "human_spans": []}
+
+    def prepare_human(self, human_texts: List[str]) -> List[str]:
+        return [
+            "".join(doc_sentences)
+            for doc_sentences in self.workspace["human_spans"]
+        ]
+
+    def _extract(self, dataset: Dataset) -> Dict[str, List[str]]:
+        text_column = self.input_config.dataset_text_column
+        texts = spacy_pipeline(
+            texts=dataset[text_column], language=self.input_config.language
+        )
+        sentences_to_rewrite = []
+        for text in texts:
+            sentences = list([sent.text_with_ws for sent in text.sents])
+            self.workspace["human_spans"].append(sentences)
+            n_sentences_to_select = randint(
+                1,
+                ceil(uniform(*self.args["percentage_range"]) * len(sentences)),
+            )
+            sampled_positions = [_ for _ in range(len(sentences))]
+            shuffle(sampled_positions)
+            sampled_positions = sorted(
+                sampled_positions[:n_sentences_to_select]
+            )
+            self.workspace["positions"].append(sampled_positions)
+            for position in sampled_positions:
+                sentences_to_rewrite.append(sentences[position])
+        return {
+            "sentence": list(map(str, sentences_to_rewrite)),
+        }

--- a/text_machina/src/extractors/sentence_rewriting.py
+++ b/text_machina/src/extractors/sentence_rewriting.py
@@ -1,9 +1,10 @@
 from math import ceil
 from random import randint, shuffle, uniform
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from datasets import Dataset
 
+from ..common.exceptions import ExtractorInvalidArgs
 from ..config import InputConfig
 from ..types import TaskType
 from .base import Extractor
@@ -29,11 +30,19 @@ class SentenceRewriting(Extractor):
     """
 
     def __init__(self, input_config: InputConfig, task_type: TaskType):
-        super().__init__(input_config, task_type)
-        self.args = self.input_config.extractor_args.get(
+        args: Dict[str, Any] = input_config.extractor_args.get(
             "sentence_rewriting", {}
         )
-        self.workspace = {"positions": [], "human_spans": []}
+        workspace: Dict[str, Any] = {"positions": [], "human_spans": []}
+        super().__init__(input_config, task_type, workspace, args)
+
+    def check_valid_args(self):
+        mandatory_args = ["percentage_range"]
+        for mandatory_arg in mandatory_args:
+            if mandatory_arg not in self.args:
+                raise ExtractorInvalidArgs(
+                    self.__class__.__name__, mandatory_args
+                )
 
     def prepare_human(self, human_texts: List[str]) -> List[str]:
         return [

--- a/text_machina/src/extractors/word_gap.py
+++ b/text_machina/src/extractors/word_gap.py
@@ -1,9 +1,10 @@
 from math import ceil
 from random import randint
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from datasets import Dataset
 
+from ..common.exceptions import ExtractorInvalidArgs
 from ..config import InputConfig
 from ..types import TaskType
 from .base import Extractor
@@ -37,13 +38,26 @@ class WordGap(Extractor):
     """
 
     def __init__(self, input_config: InputConfig, task_type: TaskType):
-        super().__init__(input_config, task_type)
-        self.args = self.input_config.extractor_args.get("word_gap", {})
-        self.workspace = {
+        args: Dict[str, Any] = input_config.extractor_args.get("word_gap", {})
+        workspace: Dict[str, Any] = {
             "positions": [],
             "human_spans": [],
             "num_boundaries": [],
         }
+        super().__init__(input_config, task_type, workspace, args)
+
+    def check_valid_args(self):
+        mandatory_args = [
+            "gap_token",
+            "max_percentage_boundaries",
+            "max_word_span",
+            "range_boundary_size",
+        ]
+        for mandatory_arg in mandatory_args:
+            if mandatory_arg not in self.args:
+                raise ExtractorInvalidArgs(
+                    self.__class__.__name__, mandatory_args
+                )
 
     def prepare_human(self, human_texts: List[str]) -> List[str]:
         return [

--- a/text_machina/src/extractors/word_masking.py
+++ b/text_machina/src/extractors/word_masking.py
@@ -1,10 +1,11 @@
 from math import ceil
 from random import choice, randint, uniform
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from datasets import Dataset
 
 from ..common import color_log, get_logger
+from ..common.exceptions import ExtractorInvalidArgs
 from ..config import InputConfig
 from ..types import TaskType
 from .base import Extractor
@@ -34,9 +35,11 @@ class WordMasking(Extractor):
     """
 
     def __init__(self, input_config: InputConfig, task_type: TaskType):
-        super().__init__(input_config, task_type)
-        self.args = self.input_config.extractor_args.get("word_masking", {})
-        self.workspace = {"masked_texts": []}
+        args: Dict[str, Any] = input_config.extractor_args.get(
+            "word_masking", {}
+        )
+        workspace: Dict[str, Any] = {"masked_texts": []}
+        super().__init__(input_config, task_type, workspace, args)
 
         _logger.warn(
             color_log(
@@ -48,6 +51,14 @@ class WordMasking(Extractor):
                 "bold_yellow",
             )
         )
+
+    def check_valid_args(self):
+        mandatory_args = ["mask_token", "percentage_range", "span_length_range"]
+        for mandatory_arg in mandatory_args:
+            if mandatory_arg not in self.args:
+                raise ExtractorInvalidArgs(
+                    self.__class__.__name__, mandatory_args
+                )
 
     def prepare_human(self, human_texts: List[str]) -> List[str]:
         return human_texts

--- a/text_machina/src/generators/mixcase.py
+++ b/text_machina/src/generators/mixcase.py
@@ -8,7 +8,13 @@ from datasets import Dataset, concatenate_datasets
 from ..common import color_log, get_logger
 from ..common.exceptions import DatasetGenerationError
 from ..config import Config
-from ..extractors import Extractor, SentenceGap, WordGap
+from ..extractors import (
+    Extractor,
+    SentenceGap,
+    SentenceMasking,
+    WordGap,
+    WordMasking,
+)
 from ..models.types import GENERATION_ERROR
 from ..types import DetectionLabels, LabeledSpan, Placeholders
 from .base import DatasetGenerator
@@ -27,8 +33,13 @@ class MixCaseDatasetGenerator(DatasetGenerator):
     def _pack(self, generations: List[str], **kwargs) -> Dataset:
         if isinstance(self.prompter.extractor, (SentenceGap, WordGap)):
             packer: Type[MixCasePacker] = MixCaseGapPacker
-        else:
+        elif isinstance(
+            self.prompter.extractor, (SentenceMasking, WordMasking)
+        ):
             packer = MixCaseMaskPacker
+        else:
+            packer = MixCaseRewritingPacker
+
         return packer(self.config, self.prompter.extractor)._pack(
             generations, **kwargs
         )
@@ -76,6 +87,195 @@ class MixCasePacker(ABC):
             Dataset: a dataset including all the texts.
         """
         ...
+
+
+class MixCaseRewritingPacker(MixCasePacker):
+    """
+    Packer for mixcase task type when using rewriting-based extractors.
+    """
+
+    def __init__(self, config: Config, extractor: Extractor) -> None:
+        super().__init__(config=config, extractor=extractor)
+
+    def _build_samples(
+        self,
+        generations: List[str],
+    ) -> Tuple[List[str], List[List[Dict]]]:
+        """
+        Interleaves generated and human spans to build mixcase samples.
+        The `start` and `end` of the labels follow the Python [`start`, `end`)
+        convention, i.e., including the `start` element and excluding `end`.
+        For instance, given the text: "I like Apolo. I don't like Athenea",
+        being the first sentence human-written and the second one generated,
+        the labels will be:
+        [
+            {"start": 0, "end": 14, "label": "human"},
+            {"start": 14, "end": 34, "label": "generated"},
+        ]
+
+        Args:
+            generations (List[str]): list of generations
+
+        Returns:
+            Tuple[List[str], List[List[Dict]]]: the interleaved texts and
+            the list of labels of each text.
+        """
+        texts, labels = [], []
+
+        prev_sample = 0
+        for sentences, positions in zip(
+            self.extractor.workspace["human_spans"],
+            self.extractor.workspace["positions"],
+        ):
+            rewrittens = generations[prev_sample : prev_sample + len(positions)]
+            positions = sorted(positions)
+            sample_labels: List[Dict] = []
+
+            # Replace rewritten sentences
+            sentences_with_rewrites = sentences[:]
+            for idx, position in enumerate(positions):
+                sentences_with_rewrites[position] = rewrittens[idx]
+            sample_text = "".join(sentences_with_rewrites)
+
+            # Mark generated spans
+            generated_labels = []
+            for idx, position in enumerate(positions):
+                start_pos = len("".join(sentences_with_rewrites[:position]))
+                end_pos = len("".join(sentences_with_rewrites[: position + 1]))
+                generated_labels.append(
+                    LabeledSpan(
+                        start=start_pos,
+                        end=end_pos,
+                        label=DetectionLabels.GENERATED.value,
+                    ).model_dump()
+                )
+
+            # Mark human spans
+            human_labels = []
+            prev_generated_position = 0
+            for idx in range(len(generated_labels)):
+                generated_label = generated_labels[idx]
+                print(prev_generated_position, generated_label["start"])
+                if prev_generated_position < generated_label["start"]:
+                    human_labels.append(
+                        LabeledSpan(
+                            start=prev_generated_position,
+                            end=generated_label["start"],
+                            label=DetectionLabels.HUMAN.value,
+                        ).model_dump()
+                    )
+                prev_generated_position = generated_label["end"]
+
+            # Add human label if the end of the text has not been
+            # reached by the last generated span
+            last_generated_position = generated_labels[-1]["end"]
+            if last_generated_position < len(sample_text):
+                human_labels.append(
+                    LabeledSpan(
+                        start=last_generated_position,
+                        end=len(sample_text),
+                        label=DetectionLabels.HUMAN.value,
+                    ).model_dump()
+                )
+            # Merge generated and human spans
+            # Join generated labels with human labels and merge overlappings.
+            merged_labels = sorted(
+                human_labels + generated_labels, key=lambda span: span["start"]
+            )
+            sample_labels = []
+            while len(merged_labels):
+                current_span = merged_labels.pop(0)
+                current_label = current_span["label"]
+                spans_with_same_label = []
+                while (
+                    len(merged_labels)
+                    and merged_labels[0]["label"] == current_label
+                ):
+                    spans_with_same_label.append(merged_labels.pop(0))
+
+                if not spans_with_same_label:
+                    sample_labels.append(current_span)
+                else:
+                    sample_labels.append(
+                        LabeledSpan(
+                            start=current_span["start"],
+                            end=spans_with_same_label[-1]["end"],
+                            label=current_label,
+                        ).model_dump()
+                    )
+
+            prev_sample += len(positions)
+            texts.append("".join(sentences_with_rewrites))
+            labels.append(sample_labels)
+        return texts, labels
+
+    def _pack(self, generations: List[str], **kwargs) -> Dataset:
+        """
+        Combines and labels the generated and human texts
+        when using rewriting-based extractors (`sentence_rewriting`)
+
+        Args:
+            generations (List[str]): list of generated texts.
+            kwargs: additional keyword arguments.
+
+        Returns:
+            Dataset: a dataset including all the texts.
+        """
+        prompted_dataset = kwargs.get("prompted_dataset", None)
+        if prompted_dataset is None:
+            raise DatasetGenerationError(f"prompted_dataset not found: {self}")
+
+        model_name = self.config.model.model_name
+        domain = self.config.input.domain
+        extractor_name = self.config.input.extractor
+        texts, labels = self._build_samples(generations)
+
+        prev_sample = 0
+        mixed_samples = []
+        for idx, (text, sample_labels) in enumerate(zip(texts, labels)):
+            n_positions = len(self.extractor.workspace["positions"][idx])
+            prompt = prompted_dataset.prompted_texts[
+                prev_sample : prev_sample + n_positions
+            ] or [Placeholders.NO_PROMPT.value]
+
+            mixed_samples.append(
+                {
+                    "prompt": prompt,
+                    "text": text,
+                    "label": sample_labels,
+                    "model": model_name,
+                    "domain": domain,
+                    "extractor": extractor_name,
+                }
+            )
+            prev_sample += n_positions
+
+        mixed_dataset = Dataset.from_list(mixed_samples)
+
+        human_dataset = Dataset.from_list(
+            [
+                {
+                    "prompt": [Placeholders.NO_PROMPT.value],
+                    "text": text,
+                    "label": [
+                        LabeledSpan(
+                            start=0,
+                            end=len(text),
+                            label=DetectionLabels.HUMAN.value,
+                        ).model_dump()
+                    ],
+                    "model": DetectionLabels.HUMAN.value,
+                    "domain": domain,
+                    "extractor": Placeholders.NO_EXTRACTOR.value,
+                }
+                for text in prompted_dataset.human_texts
+            ]
+        )
+
+        dataset = concatenate_datasets([human_dataset, mixed_dataset])
+        dataset = dataset.shuffle()
+
+        return dataset
 
 
 class MixCaseMaskPacker(MixCasePacker):

--- a/text_machina/src/generators/mixcase.py
+++ b/text_machina/src/generators/mixcase.py
@@ -155,7 +155,6 @@ class MixCaseRewritingPacker(MixCasePacker):
             prev_generated_position = 0
             for idx in range(len(generated_labels)):
                 generated_label = generated_labels[idx]
-                print(prev_generated_position, generated_label["start"])
                 if prev_generated_position < generated_label["start"]:
                     human_labels.append(
                         LabeledSpan(
@@ -177,7 +176,7 @@ class MixCaseRewritingPacker(MixCasePacker):
                         label=DetectionLabels.HUMAN.value,
                     ).model_dump()
                 )
-            # Merge generated and human spans
+
             # Join generated labels with human labels and merge overlappings.
             merged_labels = sorted(
                 human_labels + generated_labels, key=lambda span: span["start"]


### PR DESCRIPTION
This PR adds:

- Sentence rewriting extractor and packer to generate mixcase datasets. Contrary to `gap` and `masking`, a set of sentences of the documents are selected and the LLM has to rewrite them in its own words.
- Remove private methods from the documentation.