### PR TITLE
Make cache name hashable based on config

### DIFF
--- a/text_machina/src/data.py
+++ b/text_machina/src/data.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -252,13 +254,12 @@ def get_save_path(
         Path: path to save a dataset.
 
     """
-    model_name = config.safe_model_name()
-    dataset_name = config.safe_dataset_name()
-    domain = config.safe_domain_name()
+    config_as_string = json.dumps(
+        config.model_dump(), sort_keys=True, default=str
+    ).encode()
+    prefix = hashlib.sha256(config_as_string).hexdigest()
 
     parent = save_dir / run_name
-
-    prefix = f"{domain}_{dataset_name}_{model_name}"
     save_path = parent / prefix
 
     # check if path with prefix exists

--- a/text_machina/src/extractors/utils.py
+++ b/text_machina/src/extractors/utils.py
@@ -40,7 +40,9 @@ def get_spacy_model(language: str) -> spacy.lang:
     Returns:
         spacy.lang: a Spacy model.
     """
-    spacy_model = SPACY_MODEL_MAPPING.get(language, SPACY_MODEL_MAPPING["multilingual"])
+    spacy_model = SPACY_MODEL_MAPPING.get(
+        language, SPACY_MODEL_MAPPING["multilingual"]
+    )
 
     try:
         nlp = spacy.load(spacy_model)

--- a/text_machina/version.py
+++ b/text_machina/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "0"
 _MINOR = "2"
-_REVISION = "4"
+_REVISION = "5"
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
 VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)


### PR DESCRIPTION
This PR modifies the caching mechanism to instead use a hash of the full config to produce the cached dataset name, removing any possibility of cache conflicts.