### PR TITLE
Fixed posix paths

### DIFF
--- a/text_machina/cli_utils.py
+++ b/text_machina/cli_utils.py
@@ -117,7 +117,7 @@ def generate_dataset(
 
     dataset = postprocess(dataset, configs[0].task_type)
 
-    dataset.save_to_disk(save_dir)
+    dataset.save_to_disk(save_dir.as_posix())
 
     _logger.info(
         f"A total of {errors} errors have been found in the generation process."

--- a/text_machina/src/data.py
+++ b/text_machina/src/data.py
@@ -185,7 +185,7 @@ def serialize_dataset(
 
     save_path.mkdir(parents=True, exist_ok=True)
 
-    dataset.save_to_disk(save_path)
+    dataset.save_to_disk(save_path.as_posix())
     _logger.info(f"The dataset has been saved in {save_path}")
 
     return save_path
@@ -203,10 +203,12 @@ def concatenate(paths: List[Path], save_path: Path) -> Dataset:
         Dataset: the merged dataset.
     """
     save_path.mkdir(parents=True, exist_ok=True)
-    dataset = load_from_disk(paths[0])
+    dataset = load_from_disk(paths[0].as_posix())
 
     for path in paths[1:]:
-        dataset = concatenate_datasets([dataset, load_from_disk(path)])
+        dataset = concatenate_datasets(
+            [dataset, load_from_disk(path.as_posix())]
+        )
 
     return dataset
 

--- a/text_machina/src/metrics/token_classification.py
+++ b/text_machina/src/metrics/token_classification.py
@@ -115,9 +115,11 @@ def prepare_dataset(
         batched=True,
     )
     dataset = dataset.map(
-        prepare_tags_for_mixcase
-        if task_type == TaskType.MIXCASE
-        else prepare_tags_for_boundary,
+        (
+            prepare_tags_for_mixcase
+            if task_type == TaskType.MIXCASE
+            else prepare_tags_for_boundary
+        ),
         input_columns=["offset_mapping", "label"],
         batched=True,
         fn_kwargs={"label_mapping": label_mapping},

--- a/text_machina/src/models/bedrock.py
+++ b/text_machina/src/models/bedrock.py
@@ -100,9 +100,9 @@ class BedrockModel(TextGenerationModel):
             request_body = {"prompt": prompt, **generation_config}
         elif bedrock_provider == "anthropic":
             if "maxTokenCount" in generation_config:
-                generation_config[
-                    "max_tokens_to_sample"
-                ] = generation_config.pop("maxTokenCount")
+                generation_config["max_tokens_to_sample"] = (
+                    generation_config.pop("maxTokenCount")
+                )
             request_body = {"prompt": prompt, **generation_config}
         elif bedrock_provider == "cohere":
             # length constrainers work directly on providers themselves

--- a/text_machina/version.py
+++ b/text_machina/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "0"
 _MINOR = "2"
-_REVISION = "6"
+_REVISION = "7"
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
 VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)


### PR DESCRIPTION
Recent versions of `datasets` do not allow to use `PosixPath` arguments in `save_to_disk` and `load_from_disk`. This PR converts `PosixPath` to `str` in all the methods.