### PR TITLE
Added example extractor

### DIFF
--- a/etc/examples/learning/extractors/boundary_sentence_prefix.yaml
+++ b/etc/examples/learning/extractors/boundary_sentence_prefix.yaml
@@ -22,9 +22,9 @@ input_config:
         Text: 
 
     # Extractor params
-      # Without specifying the `k` (number of sentences) argument,
+    # Without specifying the `k` (number of sentences) argument,
     # the `sentence_prefix` extractor will randomly sample the
-    # sentence-length of the prefixes.
+    # sentence length of the prefixes.
     extractor: sentence_prefix
     max_input_tokens: 256
     

--- a/etc/examples/learning/extractors/detection_examples.yaml
+++ b/etc/examples/learning/extractors/detection_examples.yaml
@@ -1,0 +1,56 @@
+# Config for everything related to dataset generation inputs
+input_config:
+
+    # Dataset metadata
+    domain: legal
+    language: de
+    
+    # Dataset generator parameters
+    quantity: 10
+    random_sample_human: true
+
+    
+    # HuggingFace dataset params
+    dataset: coastalcph/multi_eurlex
+    dataset_text_column: text
+    dataset_params:
+        split: train
+        name: de
+
+    # Prompt template
+    template: >-
+        Write a legal document in German. Here you have some examples:\n
+        - Example 1: {example_1}\n
+        - Example 2: {example_2}\n
+        Document: 
+        
+    # Extractor params
+    # The `example` extractor fills the prompt template with the text column
+    # of randomly sampled (w/o replacement) examples from the dataset.
+    # You can specify if the examples will be random for all the samples
+    # (`all_random` to True) or be the same for all the samples
+    # (`all_random` to False). Also, the extractor accepts the random `seed`.
+    extractor: example
+    extractor_args:
+        example:
+            all_random: true
+            seed: 13
+
+    max_input_tokens: 256
+    
+# Config for model instantiation
+# Requires `OPENAI_API_KEY=<key>` environment variable.
+model_config:
+    provider: openai
+    model_name: gpt-3.5-turbo-instruct
+    api_type: COMPLETION
+    threads: 8
+    max_retries: 5
+    timeout: 120
+    
+# Decoding args
+generation_config:
+    # Ignore use `max_tokens` to get automatic length estimation
+    # max_tokens: 100
+    temperature: 0.7
+    presence_penalty: 1.0

--- a/text_machina/src/data.py
+++ b/text_machina/src/data.py
@@ -55,6 +55,7 @@ class PromptedDatasetBuilder:
         # truncate the prompt inputs and format the prompts
         prompt_inputs = self.truncate_inputs(prompt_inputs)
         inputs = format_prompt(self.prompt.template, prompt_inputs)
+
         return PromptedDataset(prompted_texts=inputs, human_texts=human_texts)
 
     def sampling(self, dataset: Dataset) -> Tuple[List[str], Dataset]:

--- a/text_machina/src/extractors/__init__.py
+++ b/text_machina/src/extractors/__init__.py
@@ -8,6 +8,7 @@ from .base import Extractor
 from .combined import Combined
 from .dummy import Dummy
 from .entity_list import EntityList
+from .example import Example
 from .noun_list import NounList
 from .sentence_gap import SentenceGap
 from .sentence_masking import SentenceMasking
@@ -30,6 +31,7 @@ EXTRACTORS: Mapping[str, Type[Extractor]] = {
     "word_prefix": WordPrefix,
     "word_gap": WordGap,
     "word_masking": WordMasking,
+    "example": Example,
 }
 
 

--- a/text_machina/src/extractors/example.py
+++ b/text_machina/src/extractors/example.py
@@ -1,0 +1,61 @@
+import random
+import re
+from collections import defaultdict
+from typing import Dict, List
+
+from datasets import Dataset
+
+from ..config import InputConfig
+from ..types import TaskType
+from .base import Extractor
+
+
+class Example(Extractor):
+    """
+    Extractor that fills the prompt template with the text column
+    of randomly sampled (w/o replacement) examples from the dataset.
+
+    This extractor needs as many template placeholders named {example_i}
+    as examples you want to include in the prompt.
+
+    This extractor accepts the following arguments in the `extractor_args`
+    field from the config:
+        - all_random (bool): whether if the examples must be random
+                             for each sample or not.
+        - seed (int): the random seed.
+    """
+
+    def __init__(self, input_config: InputConfig, task_type: TaskType):
+        super().__init__(input_config, task_type)
+        self.args = self.input_config.extractor_args.get("example", {})
+        self.all_random = self.args.get("all_random", True)
+        self.seed = self.args.get("seed", 13)
+
+    def _extract(self, dataset: Dataset) -> Dict[str, List[str]]:
+        regex = r"\{(example_\d+)\}"
+        example_placeholders = re.findall(regex, self.input_config.template)
+        output = defaultdict(list)
+
+        # Same examples for all the samples
+        if not self.all_random:
+            random_fixed = random.Random(self.seed)
+            examples = dataset.select(
+                random_fixed.sample(
+                    range(len(dataset)), len(example_placeholders)
+                )
+            )[self.input_config.dataset_text_column]
+
+            for idx, placeholder in enumerate(example_placeholders):
+                output[placeholder] = [examples[idx]] * len(dataset)
+        # Random examples for each sample
+        else:
+            for _ in range(len(dataset)):
+                examples = dataset.select(
+                    random.sample(
+                        range(len(dataset)), len(example_placeholders)
+                    )
+                )[self.input_config.dataset_text_column]
+                for idx, placeholder in enumerate(example_placeholders):
+                    output[placeholder].append(examples[idx])
+
+        return dict(output)

--- a/text_machina/version.py
+++ b/text_machina/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "0"
 _MINOR = "2"
-_REVISION = "9"
+_REVISION = "10"
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
 VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)


### PR DESCRIPTION
This PR adds an `Example` extractor to fill the templates with examples from the dataset. For instance, you can define prompts like:

```
Write a legal document in German. Here you have some examples:
- Example 1: {example_1}\n
- Example 2: {example_2}\n
Document: 
```

or combine it with another extractors, e.g.:

```
Write a legal document in German. Here you have some examples:\n
- Example 1: {example_1}\n
- Example 2: {example_2}\n
You must use the following entities: {entities}.
Document: 
```