### PR TITLE
Add DeepInfra and OpenRouter

### DIFF
--- a/etc/examples/learning/providers/deep_infra.yaml
+++ b/etc/examples/learning/providers/deep_infra.yaml
@@ -1,0 +1,43 @@
+# Config for everything related to dataset generation inputs
+input_config:
+    # Dataset metadata
+    domain: tweets
+    language: en
+
+    # Dataset generator parameters
+    quantity: 10
+    random_sample_human: true
+    
+    # HuggingFace dataset params
+    dataset: tweet_eval
+    dataset_text_column: text
+    dataset_params:
+        split: train
+        name: irony
+
+    # Prompt template
+    template: >-
+        Write a tweet response to the following tweet:\n'{text}'\n\nTweet: 
+
+    # Extractor params
+    extractor: auxiliary
+    max_input_tokens: 256
+    
+# Config for model instantiation
+# Requires `DEEP_INFRA_API_KEY=<key>` environment variable.
+model_config:
+    provider: deep_infra
+    base_url: https://api.deepinfra.com/v1/openai
+    # `model_name` must be the deployment name, not the backbone model
+    model_name: mistralai/Mixtral-8x22B-Instruct-v0.1
+    api_type: CHAT
+    threads: 8
+    max_retries: 10
+    timeout: 120
+    
+# Decoding args
+generation_config:
+    # Ignore use `max_tokens` to get automatic length estimation
+    # max_tokens: 100
+    temperature: 0.7
+    presence_penalty: 1.0

--- a/etc/examples/learning/providers/open_router.yaml
+++ b/etc/examples/learning/providers/open_router.yaml
@@ -1,0 +1,42 @@
+# Config for everything related to dataset generation inputs
+input_config:
+    # Dataset metadata
+    domain: tweets
+    language: en
+
+    # Dataset generator parameters
+    quantity: 10
+    random_sample_human: true
+    
+    # HuggingFace dataset params
+    dataset: tweet_eval
+    dataset_text_column: text
+    dataset_params:
+        split: train
+        name: irony
+    
+    # Prompt template
+    template: >- 
+        Write a tweet response to the following tweet:\n'{text}'. \nResponse: 
+    
+    # Extractor params
+    extractor: auxiliary
+    max_input_tokens: 256
+
+# Config for model instantiation
+# Requires `OPENROUTER_API_KEY=<token>` environment variable.
+model_config:
+    provider: open_router
+    model_name: mistralai/mixtral-8x22b-instruct
+    url: https://openrouter.ai/api/v1/chat/completions
+    max_retries: 10
+    threads: 8
+
+# Decoding args
+generation_config:
+    # Ignore `max_new_tokens` or `min_new_tokens` to get automatic length estimation
+    # min_new_tokens: 5
+    # max_new_tokens: 10
+    top_p: 0.9
+    temperature: 0.6
+    repetition_penalty: 1.0

--- a/text_machina/src/constrainers/length.py
+++ b/text_machina/src/constrainers/length.py
@@ -52,6 +52,8 @@ class LengthConstrainer(Constrainer, ABC):
             "cohere",
             "ai21",
             "inference_server",
+            "open_router",
+            "deep_infra",
         ]:
             return {"max_tokens": max_new_tokens}
         elif self.provider == "vertex":

--- a/text_machina/src/models/__init__.py
+++ b/text_machina/src/models/__init__.py
@@ -17,6 +17,8 @@ MODELS: Mapping[str, str] = {
     "ai21": "AI21Model",
     "azure_openai": "AzureOpenAIModel",
     "inference_server": "InferenceServerModel",
+    "open_router": "OpenRouterModel",
+    "deep_infra": "DeepInfraModel",
 }
 
 

--- a/text_machina/src/models/deep_infra.py
+++ b/text_machina/src/models/deep_infra.py
@@ -1,0 +1,25 @@
+import os
+
+from openai import OpenAI
+
+from ..common.utils import get_instantiation_args
+from ..config import ModelConfig
+from .openai import OpenAIModel
+
+
+class DeepInfraModel(OpenAIModel):
+    """
+    Generates completions using DeepInfra models using the OpenAI interface.
+
+    Requires the definition of the `DEEP_INFRA_API_KEY=<key>` env variable.
+    """
+
+    def __init__(self, model_config: ModelConfig):
+        self.model_config = model_config
+        self.model_name = model_config.model_name
+        self.client = OpenAI(
+            api_key=os.environ["DEEP_INFRA_API_KEY"],
+            **get_instantiation_args(
+                OpenAI.__init__, self.model_config.model_dump()
+            ),
+        )

--- a/text_machina/src/models/inference_server.py
+++ b/text_machina/src/models/inference_server.py
@@ -35,10 +35,8 @@ class InferenceServerModel(TextGenerationModel):
         self.client = requests.Session()
         retry_adapter = HTTPAdapter(
             max_retries=Retry(
-                total=getattr(self.model_config, "max_retries", 5),
-                backoff_factor=getattr(
-                    self.model_config, "backoff_factor", 0.5
-                ),
+                total=getattr(self.model_config, "max_retries", 10),
+                backoff_factor=getattr(self.model_config, "backoff_factor", 2),
                 status_forcelist=[
                     code for code in requests.status_codes._codes if code != 200
                 ],

--- a/text_machina/src/models/open_router.py
+++ b/text_machina/src/models/open_router.py
@@ -3,22 +3,21 @@ from typing import Dict
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
-from transformers import AutoTokenizer
 
 from ..common.logging import get_logger
 from ..config import ModelConfig
 from .base import TextGenerationModel
-from .types import GENERATION_ERROR, CompletionType
+from .types import GENERATION_ERROR
 
 _logger = get_logger(__name__)
 
 
-class HuggingFaceRemoteModel(TextGenerationModel):
+class OpenRouterModel(TextGenerationModel):
     """
     Generates completions using HuggingFace's models remotely deployed
     (HuggingFace's Inference API or Inference Endpoints).
 
-    Requires the definition of the `HF_TOKEN=<token>` environment variable.
+    Requires the definition of the `OPENROUTER_API_KEY=<token>` environment variable.
     """
 
     def __init__(self, model_config: ModelConfig):
@@ -36,33 +35,22 @@ class HuggingFaceRemoteModel(TextGenerationModel):
         self.client.mount("http://", retry_adapter)
         self.client.mount("https://", retry_adapter)
 
-        if self.model_config.api_type == CompletionType.CHAT:
-            self.tokenizer = AutoTokenizer.from_pretrained(
-                self.model_config.model_name
-            )
-
     def generate_completion(self, prompt: str, generation_config: Dict) -> str:
-        headers = {"Authorization": f'Bearer {os.environ["HF_TOKEN"]}'}
-
-        inputs = prompt
-        if self.model_config.api_type == CompletionType.CHAT:
-            inputs = self.tokenizer.apply_chat_template(
-                [
-                    {"role": "user", "content": prompt},
-                ],
-                add_generation_prompt=True,
-                tokenize=False,
-            )
+        headers = {
+            "Authorization": f'Bearer {os.environ["OPENROUTER_API_KEY"]}'
+        }
 
         payload = {
-            "inputs": inputs,
-            "parameters": generation_config,
+            "model": self.model_config.model_name,
+            "messages": [{"role": "user", "content": prompt}],
+            **generation_config,
         }
+
         try:
             response = self.client.post(
                 self.model_config.url, headers=headers, json=payload
             )
-            return response.json()[0]["generated_text"]
+            return response.json()["choices"][0]["message"]["content"]
         except Exception as e:
             _logger.info(f"Unrecoverable exception during the request: {e}")
             return GENERATION_ERROR

--- a/text_machina/src/tokenizers/__init__.py
+++ b/text_machina/src/tokenizers/__init__.py
@@ -20,6 +20,8 @@ TOKENIZERS: Mapping[str, str] = {
     "ai21": "AI21Tokenizer",
     "azure_openai": "AzureOpenAITokenizer",
     "inference_server": "InferenceServerTokenizer",
+    "open_router": "OpenRouterTokenizer",
+    "deep_infra": "DeepInfraTokenizer",
 }
 
 

--- a/text_machina/src/tokenizers/deep_infra.py
+++ b/text_machina/src/tokenizers/deep_infra.py
@@ -1,0 +1,23 @@
+from typing import List
+
+import tiktoken
+
+from .base import Tokenizer
+
+
+class DeepInfraTokenizer(Tokenizer):
+    """
+    Tokenizer for DeepInfra models.
+
+    DeepInfra does not offer tokenizers. GPT-4 Tokenizer is used instead.
+    """
+
+    def __init__(self, model_name: str):
+        super().__init__(model_name)
+        self.tokenizer = tiktoken.encoding_for_model("gpt-4")
+
+    def encode(self, text: str) -> List[int]:
+        return self.tokenizer.encode(text)
+
+    def decode(self, tokens: List[int]) -> str:
+        return self.tokenizer.decode(tokens)

--- a/text_machina/src/tokenizers/open_router.py
+++ b/text_machina/src/tokenizers/open_router.py
@@ -1,0 +1,23 @@
+from typing import List
+
+import tiktoken
+
+from .base import Tokenizer
+
+
+class OpenRouterTokenizer(Tokenizer):
+    """
+    Tokenizer for OpenRouter models.
+
+    OpenRouter does not offer tokenizers. GPT-4 Tokenizer is used instead.
+    """
+
+    def __init__(self, model_name: str):
+        super().__init__(model_name)
+        self.tokenizer = tiktoken.encoding_for_model("gpt-4")
+
+    def encode(self, text: str) -> List[int]:
+        return self.tokenizer.encode(text)
+
+    def decode(self, tokens: List[int]) -> str:
+        return self.tokenizer.decode(tokens)


### PR DESCRIPTION
This PR adds:

- Two providers: [DeepInfra](https://deepinfra.com/) and [OpenRouter](https://openrouter.ai/).
- Better default args for `hf_remote` and `inference_server`